### PR TITLE
feat: #12 — Missing CSRF protection in user preference update endpoint

### DIFF
--- a/.pipeline/code-r1.json
+++ b/.pipeline/code-r1.json
@@ -1,0 +1,6 @@
+[
+  {
+    "file": "user/preferences.php",
+    "content": "<?php\n// This file is part of Moodle - http://moodle.org/\n//\n// Moodle is free software: you can redistribute it and/or modify\n// it under the terms of the GNU General Public License as published by\n// the Free Software Foundation, either version 3 of the License, or\n// (at your option) any later version.\n//\n// Moodle is distributed in the hope that it will be useful,\n// but WITHOUT ANY WARRANTY; without even the implied warranty of\n// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n// GNU General Public License for more details.\n//\n// You should have received a copy of the GNU General Public License\n// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.\n\ndefined('MOODLE_INTERNAL') || die();\n\nrequire_once(__DIR__.'/../../config.php');\nrequire_once($CFG->dirroot.'/user/lib.php');\n\nrequire_login();\nrequire_sesskey();\n\n// Example: process preference update\n$preference = required_param('preference', PARAM_TEXT);\n$value = required_param('value', PARAM_RAW);\n\n// Save preference for current user.\nset_user_preference($preference, $value, $USER);\n\n// Redirect or return some response.\necho get_string('preferencessaved', 'core_user');\n"
+  }
+]

--- a/.pipeline/code-r2.json
+++ b/.pipeline/code-r2.json
@@ -1,0 +1,6 @@
+[
+  {
+    "file": "user/preferences.php",
+    "content": "<?php\n// This file is part of Moodle - http://moodle.org/\n//\n// Moodle is free software: you can redistribute it and/or modify\n// it under the terms of the GNU General Public License as published by\n// the Free Software Foundation, either version 3 of the License, or\n// (at your option) any later version.\n//\n// Moodle is distributed in the hope that it will be useful,\n// but WITHOUT ANY WARRANTY; without even the implied warranty of\n// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n// GNU General Public License for more details.\n//\n// You should have received a copy of the GNU General Public License\n// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.\n\nuse core\\output\\notification;\n\ndefined('MOODLE_INTERNAL') || die();\n\nrequire_once(__DIR__.'/../../config.php');\nrequire_once($CFG->dirroot.'/user/lib.php');\n\nrequire_login();\nrequire_sesskey();\n\n$preference = required_param('preference', PARAM_ALPHANUMEXT);\n$value = required_param('value', PARAM_TEXT);\n\n// Save preference for current user.\nset_user_preference($preference, $value, $USER);\n\n$notification = new notification(get_string('preferencessaved', 'core_user'), notification::NOTIFY_SUCCESS);\necho $OUTPUT->render($notification);\n"
+  }
+]

--- a/.pipeline/findings-r1.json
+++ b/.pipeline/findings-r1.json
@@ -1,0 +1,23 @@
+[
+  {
+    "file": "user/preferences.php",
+    "line": 35,
+    "severity": "HIGH",
+    "issue": "Direct echo of string",
+    "suggestion": "Use $OUTPUT->render() or return HTML"
+  },
+  {
+    "file": "user/preferences.php",
+    "line": 26,
+    "severity": "MEDIUM",
+    "issue": "Use of PARAM_RAW for value parameter",
+    "suggestion": "Use PARAM_TEXT or appropriate PARAM_ type for value parameter"
+  },
+  {
+    "file": "user/preferences.php",
+    "line": 25,
+    "severity": "LOW",
+    "issue": "Missing validation for preference parameter",
+    "suggestion": "Add validation for preference parameter to ensure it meets expected format"
+  }
+]

--- a/.pipeline/findings-r2.json
+++ b/.pipeline/findings-r2.json
@@ -1,0 +1,9 @@
+[
+  {
+    "file": "user/preferences.php",
+    "line": 30,
+    "severity": "HIGH",
+    "issue": "Direct use of `echo` in a library file",
+    "suggestion": "Use `$OUTPUT->render()` or return HTML instead of `echo`"
+  }
+]

--- a/user/preferences.php
+++ b/user/preferences.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+use core\output\notification;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__.'/../../config.php');
@@ -22,12 +24,11 @@ require_once($CFG->dirroot.'/user/lib.php');
 require_login();
 require_sesskey();
 
-// Example: process preference update
-$preference = required_param('preference', PARAM_TEXT);
-$value = required_param('value', PARAM_RAW);
+$preference = required_param('preference', PARAM_ALPHANUMEXT);
+$value = required_param('value', PARAM_TEXT);
 
 // Save preference for current user.
 set_user_preference($preference, $value, $USER);
 
-// Redirect or return some response.
-echo get_string('preferencessaved', 'core_user');
+$notification = new notification(get_string('preferencessaved', 'core_user'), notification::NOTIFY_SUCCESS);
+echo $OUTPUT->render($notification);

--- a/user/preferences.php
+++ b/user/preferences.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__.'/../../config.php');
+require_once($CFG->dirroot.'/user/lib.php');
+
+require_login();
+require_sesskey();
+
+// Example: process preference update
+$preference = required_param('preference', PARAM_TEXT);
+$value = required_param('value', PARAM_RAW);
+
+// Save preference for current user.
+set_user_preference($preference, $value, $USER);
+
+// Redirect or return some response.
+echo get_string('preferencessaved', 'core_user');


### PR DESCRIPTION
## 🤖 AI-Generated Implementation

    Closes #12

    | Role | Model | Vendor |
    |---|---|---|
    | Coder | `openai/gpt-4.1-mini` | OpenAI |
    | Reviewer | `mistral-ai/mistral-small-2503` | Mistral |

    **Rounds:** 2 &nbsp;|&nbsp; **Files changed:** 1 &nbsp;|&nbsp; **Resolved:** 3 &nbsp;|&nbsp; **Unresolved:** 1

    ### Files changed
    - `user/preferences.php`

### ⚠️ Unresolved — needs human review
- **[HIGH]** `user/preferences.php:30` — Direct use of `echo` in a library file

    ---
    *Auto-generated by the agentic pipeline via GitHub Models.*